### PR TITLE
Allow searching for UNL provided users

### DIFF
--- a/src/Listener.php
+++ b/src/Listener.php
@@ -4,6 +4,7 @@ namespace SiteMaster\Plugins\Auth_unl;
 
 use SiteMaster\Core\Events\GetAuthenticationPlugins;
 use SiteMaster\Core\Events\RoutesCompile;
+use SiteMaster\Core\Events\User\Search;
 use SiteMaster\Core\Plugin\PluginListener;
 
 class Listener extends PluginListener
@@ -17,5 +18,68 @@ class Listener extends PluginListener
     public function onGetAuthenticationPlugins(GetAuthenticationPlugins $event)
     {
         $event->addPlugin($this->plugin);
+    }
+
+    public function onUserSearch(Search $event)
+    {
+        $results = array_merge(
+            $this->getSearchResults($event->getSearchTerm()),
+            $this->getSearchResultsForUID($event->getSearchTerm())
+        );
+
+        foreach ($results as $user) {
+            if (empty($user['uid'])) {
+                continue;
+            }
+
+            $uid = $user['uid'];
+            
+            $email = '';
+            if (isset($user['mail'][0])) {
+                $email = $user['mail'][0];
+            }
+            
+            $first_name = '';
+            if (isset($user['givenName'][0])) {
+                $first_name = $user['givenName'][0];
+            }
+            
+            $last_name = '';
+            if (isset($user['sn'][0])) {
+                $last_name = $user['sn'][0];
+            }
+            
+            $event->addResult('UNL', $uid, $email, $first_name, $last_name);
+        }
+    }
+    
+    protected function getSearchResults($term)
+    {
+        $url = 'http://directory.unl.edu/?q=' . urlencode($term) . '&format=json';
+
+        if (!$data = @file_get_contents($url)) {
+            return array();
+        }
+
+        if (!$json = json_decode($data, true)) {
+            return array();
+        }
+        
+        return $json;
+    }
+    
+    protected function getSearchResultsForUID($term)
+    {
+        $url = 'http://directory.unl.edu/?uid=' . urlencode($term) . '&format=json';
+
+        if (!$data = @file_get_contents($url)) {
+            return array();
+        }
+
+        if (!$json = json_decode($data, true)) {
+            return array();
+        }
+        
+        return array($json);
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,7 @@ namespace SiteMaster\Plugins\Auth_unl;
 use SiteMaster\Core\Config;
 use SiteMaster\Core\Events\GetAuthenticationPlugins;
 use SiteMaster\Core\Events\RoutesCompile;
+use SiteMaster\Core\Events\User\Search;
 use SiteMaster\Core\Plugin\AuthenticationInterface;
 use SiteMaster\Core\Plugin\PluginInterface;
 
@@ -85,6 +86,11 @@ class Plugin extends PluginInterface implements AuthenticationInterface
         $listeners[] = array(
             'event'    => GetAuthenticationPlugins::EVENT_NAME,
             'listener' => array($listener, 'onGetAuthenticationPlugins')
+        );
+
+        $listeners[] = array(
+            'event'    => Search::EVENT_NAME,
+            'listener' => array($listener, 'onUserSearch')
         );
 
         return $listeners;


### PR DESCRIPTION
Listen for onUserSearch events, which allows forms to search for UNL provided users, even if they do not exist in the system yet.  This provides a way for a registered user to add a non-registered user.
